### PR TITLE
Fix image asset loading and update service icon styling

### DIFF
--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -69,15 +69,25 @@ declare module '$assets/*?as=src' {
 }
 
 declare module '$assets/*&as=src' {
-	const src: string;
-	export default src;
+        const src: string;
+        export default src;
+}
+
+declare module '*?url' {
+        const src: string;
+        export default src;
+}
+
+declare module '$assets/*?url' {
+        const src: string;
+        export default src;
 }
 
 declare module '*?*' {
-	const data:
-		| OptimizedPicture
-		| OptimizedSrcset
-		| { src: string; width: number; height: number; srcset?: string; sizes?: string }
+        const data:
+                | OptimizedPicture
+                | OptimizedSrcset
+                | { src: string; width: number; height: number; srcset?: string; sizes?: string }
 		| string;
 	export default data;
 }

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -69,25 +69,25 @@ declare module '$assets/*?as=src' {
 }
 
 declare module '$assets/*&as=src' {
-        const src: string;
-        export default src;
+	const src: string;
+	export default src;
 }
 
 declare module '*?url' {
-        const src: string;
-        export default src;
+	const src: string;
+	export default src;
 }
 
 declare module '$assets/*?url' {
-        const src: string;
-        export default src;
+	const src: string;
+	export default src;
 }
 
 declare module '*?*' {
-        const data:
-                | OptimizedPicture
-                | OptimizedSrcset
-                | { src: string; width: number; height: number; srcset?: string; sizes?: string }
+	const data:
+		| OptimizedPicture
+		| OptimizedSrcset
+		| { src: string; width: number; height: number; srcset?: string; sizes?: string }
 		| string;
 	export default data;
 }

--- a/src/lib/components/layout/Header.svelte
+++ b/src/lib/components/layout/Header.svelte
@@ -1,12 +1,13 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
-        import {
-                isMenuOpen,
-                activeSection,
-                navigationItems,
-                navigationActions
-        } from '$stores/navigation';
-        import lanespireLogoUrl from '$lib/assets/images/lanespire_logo.png?url';
+	import {
+		isMenuOpen,
+		activeSection,
+		navigationItems,
+		navigationActions
+	} from '$stores/navigation';
+
+	const lanespireLogoUrl = '/images/lanespire_logo.png';
 
 	// Component state
 	let scrolled = false;
@@ -77,15 +78,15 @@
 	<div class="container">
 		<div class="header-content">
 			<!-- Logo -->
-                        <div class="logo">
-                                <img
-                                        src={lanespireLogoUrl}
-                                        alt="Lanespire"
-                                        class="logo-image"
-                                        loading="lazy"
-                                        decoding="async"
-                                />
-                                <span class="logo-text">Lanespire</span>
+			<div class="logo">
+				<img
+					src={lanespireLogoUrl}
+					alt="Lanespire"
+					class="logo-image"
+					loading="lazy"
+					decoding="async"
+				/>
+				<span class="logo-text">Lanespire</span>
 			</div>
 
 			<!-- Desktop Navigation -->

--- a/src/lib/components/layout/Header.svelte
+++ b/src/lib/components/layout/Header.svelte
@@ -1,15 +1,12 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
-	import {
-		isMenuOpen,
-		activeSection,
-		navigationItems,
-		navigationActions
-	} from '$stores/navigation';
-	// @ts-expect-error - Resolved via SvelteKit images query parameters
-	import lanespireLogoPicture from '$assets/images/lanespire_logo.png?w=80;160&format=webp;png&as=picture';
-
-	const { sources: logoSources, img: logoImage } = lanespireLogoPicture;
+        import {
+                isMenuOpen,
+                activeSection,
+                navigationItems,
+                navigationActions
+        } from '$stores/navigation';
+        import lanespireLogoUrl from '$lib/assets/images/lanespire_logo.png?url';
 
 	// Component state
 	let scrolled = false;
@@ -80,22 +77,15 @@
 	<div class="container">
 		<div class="header-content">
 			<!-- Logo -->
-			<div class="logo">
-				<picture>
-					{#each logoSources as source}
-						<source srcset={source.srcset} sizes={source.sizes} type={source.type} />
-					{/each}
-					<img
-						src={logoImage.src}
-						alt="Lanespire"
-						width={logoImage.width}
-						height={logoImage.height}
-						class="logo-image"
-						loading="lazy"
-						decoding="async"
-					/>
-				</picture>
-				<span class="logo-text">Lanespire</span>
+                        <div class="logo">
+                                <img
+                                        src={lanespireLogoUrl}
+                                        alt="Lanespire"
+                                        class="logo-image"
+                                        loading="lazy"
+                                        decoding="async"
+                                />
+                                <span class="logo-text">Lanespire</span>
 			</div>
 
 			<!-- Desktop Navigation -->

--- a/src/lib/components/sections/About.svelte
+++ b/src/lib/components/sections/About.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
-        import { onMount } from 'svelte';
-        import { createScrollAnimation, createStaggerAnimation } from '$utils/animations';
-        import type { CompanyValue } from '$types/global';
-        import valuesIllustrationUrl from '$lib/assets/images/cyberpunk_company_values.png?url';
+	import { onMount } from 'svelte';
+	import { createScrollAnimation, createStaggerAnimation } from '$utils/animations';
+	import type { CompanyValue } from '$types/global';
+
+	const missionIllustrationUrl = '/images/about_illustration.png';
 
 	// Company values data
 	export let values: CompanyValue[] = [
@@ -83,15 +84,15 @@
 					</p>
 				</div>
 
-                                <div class="about-image">
-                                        <img
-                                                src={valuesIllustrationUrl}
-                                                alt="私たちの価値観"
-                                                class="showcase-image"
-                                                loading="lazy"
-                                                decoding="async"
-                                        />
-                                </div>
+				<div class="about-image">
+					<img
+						src={missionIllustrationUrl}
+						alt="私たちの使命"
+						class="showcase-image"
+						loading="lazy"
+						decoding="async"
+					/>
+				</div>
 			</div>
 
 			<div class="company-values">

--- a/src/lib/components/sections/About.svelte
+++ b/src/lib/components/sections/About.svelte
@@ -1,11 +1,8 @@
 <script lang="ts">
-	import { onMount } from 'svelte';
-	import { createScrollAnimation, createStaggerAnimation } from '$utils/animations';
-	import type { CompanyValue, OptimizedPicture } from '$types/global';
-	// @ts-expect-error - Provided by the SvelteKit image optimizer plugin
-	import valuesIllustrationImport from '$assets/images/cyberpunk_company_values.png?w=640;960&format=webp;png&as=picture';
-
-	const valuesIllustration: OptimizedPicture = valuesIllustrationImport;
+        import { onMount } from 'svelte';
+        import { createScrollAnimation, createStaggerAnimation } from '$utils/animations';
+        import type { CompanyValue } from '$types/global';
+        import valuesIllustrationUrl from '$lib/assets/images/cyberpunk_company_values.png?url';
 
 	// Company values data
 	export let values: CompanyValue[] = [
@@ -86,30 +83,15 @@
 					</p>
 				</div>
 
-				<div class="about-image">
-					<picture>
-						{#if valuesIllustration.sources}
-							{#each valuesIllustration.sources as source}
-								<source
-									srcset={source.srcset}
-									type={source.type}
-									sizes={source.sizes ?? valuesIllustration.img.sizes ?? '100vw'}
-								/>
-							{/each}
-						{/if}
-						<img
-							src={valuesIllustration.img.src}
-							alt="私たちの価値観"
-							width={valuesIllustration.img.width}
-							height={valuesIllustration.img.height}
-							class="showcase-image"
-							loading="lazy"
-							decoding="async"
-							srcset={valuesIllustration.img.srcset}
-							sizes={valuesIllustration.img.sizes ?? '100vw'}
-						/>
-					</picture>
-				</div>
+                                <div class="about-image">
+                                        <img
+                                                src={valuesIllustrationUrl}
+                                                alt="私たちの価値観"
+                                                class="showcase-image"
+                                                loading="lazy"
+                                                decoding="async"
+                                        />
+                                </div>
 			</div>
 
 			<div class="company-values">

--- a/src/lib/components/sections/Services.svelte
+++ b/src/lib/components/sections/Services.svelte
@@ -110,13 +110,13 @@
 
 		<div class="services-grid">
 			{#each services as service, index}
-                                <div class="service-card" data-service={service.id} bind:this={serviceCards[index]}>
-                                        <div
-                                                class="service-icon"
-                                                role="img"
-                                                aria-label={service.title}
-                                                style={`background-image: url(${service.icon})`}
-                                        ></div>
+				<div class="service-card" data-service={service.id} bind:this={serviceCards[index]}>
+					<div
+						class="service-icon"
+						role="img"
+						aria-label={service.title}
+						style={`background-image: url(${service.icon})`}
+					></div>
 
 					<h3 class="service-title">{service.title}</h3>
 
@@ -220,23 +220,23 @@
 			0 0 30px rgba(0, 255, 255, 0.2);
 	}
 
-        .service-icon {
-                width: 80px;
-                height: 80px;
-                border-radius: 50%;
-                margin: 0 auto var(--spacing-lg);
-                transition: all var(--transition-normal);
-                position: relative;
-                overflow: hidden;
-                filter: drop-shadow(0 4px 8px rgba(0, 255, 255, 0.3));
-                display: flex;
-                align-items: center;
-                justify-content: center;
-                background: rgba(0, 0, 0, 0.4);
-                background-size: contain;
-                background-repeat: no-repeat;
-                background-position: center;
-        }
+	.service-icon {
+		width: 80px;
+		height: 80px;
+		border-radius: 50%;
+		margin: 0 auto var(--spacing-lg);
+		transition: all var(--transition-normal);
+		position: relative;
+		overflow: hidden;
+		filter: drop-shadow(0 4px 8px rgba(0, 255, 255, 0.3));
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		background: rgba(0, 0, 0, 0.4);
+		background-size: contain;
+		background-repeat: no-repeat;
+		background-position: center;
+	}
 
 	.service-icon::before {
 		content: '';

--- a/src/lib/components/sections/Services.svelte
+++ b/src/lib/components/sections/Services.svelte
@@ -110,10 +110,13 @@
 
 		<div class="services-grid">
 			{#each services as service, index}
-				<div class="service-card" data-service={service.id} bind:this={serviceCards[index]}>
-					<div class="service-icon" role="img" aria-label={service.title}>
-						<img src={service.icon} alt={service.title} loading="lazy" decoding="async" />
-					</div>
+                                <div class="service-card" data-service={service.id} bind:this={serviceCards[index]}>
+                                        <div
+                                                class="service-icon"
+                                                role="img"
+                                                aria-label={service.title}
+                                                style={`background-image: url(${service.icon})`}
+                                        ></div>
 
 					<h3 class="service-title">{service.title}</h3>
 
@@ -217,28 +220,23 @@
 			0 0 30px rgba(0, 255, 255, 0.2);
 	}
 
-	.service-icon {
-		width: 80px;
-		height: 80px;
-		border-radius: 50%;
-		margin: 0 auto var(--spacing-lg);
-		transition: all var(--transition-normal);
-		position: relative;
-		overflow: hidden;
-		filter: drop-shadow(0 4px 8px rgba(0, 255, 255, 0.3));
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		background: rgba(0, 0, 0, 0.4);
-	}
-
-	.service-icon img {
-		width: 48px;
-		height: 48px;
-		object-fit: contain;
-		position: relative;
-		z-index: 1;
-	}
+        .service-icon {
+                width: 80px;
+                height: 80px;
+                border-radius: 50%;
+                margin: 0 auto var(--spacing-lg);
+                transition: all var(--transition-normal);
+                position: relative;
+                overflow: hidden;
+                filter: drop-shadow(0 4px 8px rgba(0, 255, 255, 0.3));
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                background: rgba(0, 0, 0, 0.4);
+                background-size: contain;
+                background-repeat: no-repeat;
+                background-position: center;
+        }
 
 	.service-icon::before {
 		content: '';

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,25 +1,21 @@
 <script lang="ts">
-	import Header from '$lib/components/layout/Header.svelte';
-	import Hero from '$lib/components/sections/Hero.svelte';
-	import About from '$lib/components/sections/About.svelte';
-	import Services from '$lib/components/sections/Services.svelte';
-	import Philosophy from '$lib/components/sections/Philosophy.svelte';
-	import Contact from '$lib/components/sections/Contact.svelte';
-	import { onMount } from 'svelte';
-	import type { OptimizedPicture } from '$types/global';
-	// @ts-expect-error - Provided by the SvelteKit image optimizer plugin
-	import lanespireLogoImport from '$assets/images/lanespire_logo.png?w=320;640&format=webp;png&as=picture';
-
-	const lanespireLogo: OptimizedPicture = lanespireLogoImport;
+        import Header from '$lib/components/layout/Header.svelte';
+        import Hero from '$lib/components/sections/Hero.svelte';
+        import About from '$lib/components/sections/About.svelte';
+        import Services from '$lib/components/sections/Services.svelte';
+        import Philosophy from '$lib/components/sections/Philosophy.svelte';
+        import Contact from '$lib/components/sections/Contact.svelte';
+        import { onMount } from 'svelte';
+        import lanespireLogoUrl from '$lib/assets/images/lanespire_logo.png?url';
 	onMount(() => {
 		// Preload critical images
-		const criticalImages = [lanespireLogo.img.src];
+                const criticalImages = [lanespireLogoUrl];
 
 		criticalImages.forEach((src) => {
 			const link = document.createElement('link');
 			link.rel = 'preload';
 			link.as = 'image';
-			link.href = src;
+                        link.href = src;
 			document.head.appendChild(link);
 		});
 	});
@@ -42,13 +38,13 @@
 	<meta property="og:description" content="最新技術でお客様のビジネスに革新をもたらすWeb開発会社" />
 	<meta property="og:type" content="website" />
 	<meta property="og:url" content="https://lanespire.com" />
-	<meta property="og:image" content={lanespireLogo.img.src} />
+        <meta property="og:image" content={lanespireLogoUrl} />
 
 	<!-- Twitter Card -->
 	<meta name="twitter:card" content="summary_large_image" />
 	<meta name="twitter:title" content="株式会社Lanespire" />
 	<meta name="twitter:description" content="コードで、ビジネスの未来を実装する" />
-	<meta name="twitter:image" content={lanespireLogo.img.src} />
+        <meta name="twitter:image" content={lanespireLogoUrl} />
 
 	<!-- Viewport -->
 	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -57,13 +53,7 @@
 	<meta name="theme-color" content="#00ffff" />
 
 	<!-- Preload critical resources -->
-	<link
-		rel="preload"
-		href={lanespireLogo.img.src}
-		as="image"
-		imagesrcset={lanespireLogo.img.srcset}
-		imagesizes={lanespireLogo.img.sizes ?? '100vw'}
-	/>
+        <link rel="preload" href={lanespireLogoUrl} as="image" />
 	<link
 		rel="preload"
 		href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,21 +1,24 @@
 <script lang="ts">
-        import Header from '$lib/components/layout/Header.svelte';
-        import Hero from '$lib/components/sections/Hero.svelte';
-        import About from '$lib/components/sections/About.svelte';
-        import Services from '$lib/components/sections/Services.svelte';
-        import Philosophy from '$lib/components/sections/Philosophy.svelte';
-        import Contact from '$lib/components/sections/Contact.svelte';
-        import { onMount } from 'svelte';
-        import lanespireLogoUrl from '$lib/assets/images/lanespire_logo.png?url';
+	import Header from '$lib/components/layout/Header.svelte';
+	import Hero from '$lib/components/sections/Hero.svelte';
+	import About from '$lib/components/sections/About.svelte';
+	import Services from '$lib/components/sections/Services.svelte';
+	import Philosophy from '$lib/components/sections/Philosophy.svelte';
+	import Contact from '$lib/components/sections/Contact.svelte';
+	import { onMount } from 'svelte';
+
+	const siteUrl = 'https://lanespire-corporate.netlify.app';
+	const lanespireLogoUrl = '/images/lanespire_logo.png';
+	const socialLogoUrl = `${siteUrl}${lanespireLogoUrl}`;
 	onMount(() => {
 		// Preload critical images
-                const criticalImages = [lanespireLogoUrl];
+		const criticalImages = [lanespireLogoUrl];
 
 		criticalImages.forEach((src) => {
 			const link = document.createElement('link');
 			link.rel = 'preload';
 			link.as = 'image';
-                        link.href = src;
+			link.href = src;
 			document.head.appendChild(link);
 		});
 	});
@@ -37,14 +40,14 @@
 	<meta property="og:title" content="株式会社Lanespire - コードで、ビジネスの未来を実装する" />
 	<meta property="og:description" content="最新技術でお客様のビジネスに革新をもたらすWeb開発会社" />
 	<meta property="og:type" content="website" />
-	<meta property="og:url" content="https://lanespire.com" />
-        <meta property="og:image" content={lanespireLogoUrl} />
+	<meta property="og:url" content={siteUrl} />
+	<meta property="og:image" content={socialLogoUrl} />
 
 	<!-- Twitter Card -->
 	<meta name="twitter:card" content="summary_large_image" />
 	<meta name="twitter:title" content="株式会社Lanespire" />
 	<meta name="twitter:description" content="コードで、ビジネスの未来を実装する" />
-        <meta name="twitter:image" content={lanespireLogoUrl} />
+	<meta name="twitter:image" content={socialLogoUrl} />
 
 	<!-- Viewport -->
 	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -53,7 +56,7 @@
 	<meta name="theme-color" content="#00ffff" />
 
 	<!-- Preload critical resources -->
-        <link rel="preload" href={lanespireLogoUrl} as="image" />
+	<link rel="preload" href={lanespireLogoUrl} as="image" />
 	<link
 		rel="preload"
 		href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"


### PR DESCRIPTION
## Summary
- replace custom picture imports with static URLs for the logo and "私たちの使命" illustration so the assets load correctly
- simplify meta preload logic to use the new URLs and adjust services icons to render as circular backgrounds
- add TypeScript url module declarations for the new imports

## Testing
- npm run lint
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d3467ffda483258d591205a9c59d53