### PR TITLE
feat: Fix mobile app icon display and service worker error

### DIFF
--- a/src/lib/components/sections/Services.svelte
+++ b/src/lib/components/sections/Services.svelte
@@ -244,8 +244,9 @@
 	.service-icon-image {
 		width: 100%;
 		height: 100%;
-		object-fit: cover;
+		object-fit: contain;
 		border-radius: 50%;
+		padding: 10%; /* アイコンが丸い枠に収まるようにパディングを追加 */
 	}
 
 	.service-icon::before {

--- a/src/service-worker.ts
+++ b/src/service-worker.ts
@@ -12,7 +12,7 @@ const ASSETS = [
 	...build, // the app itself
 	...files.filter((file) => {
 		// Skip files that might cause issues
-		return !file.includes('.DS_Store') && !file.includes('Thumbs.db') && !file.endsWith('.map');
+		return !file.includes(".DS_Store") && !file.includes("Thumbs.db") && !file.endsWith(".map") && !file.startsWith("chrome-extension://");
 	})
 ];
 

--- a/src/service-worker.ts
+++ b/src/service-worker.ts
@@ -12,7 +12,12 @@ const ASSETS = [
 	...build, // the app itself
 	...files.filter((file) => {
 		// Skip files that might cause issues
-		return !file.includes(".DS_Store") && !file.includes("Thumbs.db") && !file.endsWith(".map") && !file.startsWith("chrome-extension://");
+		return (
+			!file.includes('.DS_Store') &&
+			!file.includes('Thumbs.db') &&
+			!file.endsWith('.map') &&
+			!file.startsWith('chrome-extension://')
+		);
 	})
 ];
 


### PR DESCRIPTION
モバイルアプリケーション開発のアイコンが丸く表示されるようにCSSを修正し、service-worker.jsのchrome-extensionエラーを修正しました。